### PR TITLE
Remove old accounting route

### DIFF
--- a/MentorIA/src/App.tsx
+++ b/MentorIA/src/App.tsx
@@ -30,7 +30,6 @@ function App() {
           <Route path="/" element={<WelcomePage />} />
           <Route path="/courses" element={<CourseSelectionPage />} />
           <Route path="/vark/:courseId" element={<VARKQuestionnairePage />} />
-          <Route path="/accounting" element={<AccountingCourse />} />
           <Route path="/diagnostic/:courseId" element={<DiagnosticPage />} />
           <Route path="/results/:courseId" element={<ResultsPage />} />
           <Route path="/onboarding/:courseId" element={<CourseOnboardingPage />} />

--- a/MentorIA/src/pages/CourseSelectionPage.tsx
+++ b/MentorIA/src/pages/CourseSelectionPage.tsx
@@ -31,7 +31,7 @@ const CourseSelectionPage: React.FC = () => {
   
   const handleSelectStandardCourse = (courseId: string) => {
     if (courseId === 'accounting') {
-      navigate('/accounting');
+      navigate('/contabilidad');
     } else {
       navigate(`/vark/${courseId}`);
     }


### PR DESCRIPTION
## Summary
- remove unused `/accounting` route
- update selection navigation for the accounting course

## Testing
- `npm test --silent` *(fails: network access needed)*
- `cd MentorIA && npm test --silent` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_e_685ed6354d808333a677bdfc1975f93d