### PR TITLE
Fix Contabilidad exercise loading

### DIFF
--- a/MentorIA/src/components/ExerciseDetail.jsx
+++ b/MentorIA/src/components/ExerciseDetail.jsx
@@ -5,8 +5,10 @@ import TAccountEditor from './TAccountEditor';
 import IncomeStatement from './IncomeStatement';
 
 /**
- * ExerciseDetail displays the full context for an accounting exercise and
- * optionally the list of items/questions once the user starts the exercise.
+ * ExerciseDetail
+ * --------------
+ * Renders the full context of a single accounting exercise and, when the user
+ * decides to start, shows the interactive questions below that context.
  *
  * Props:
  *   - exercise: object containing title, context_text, balance sheets, etc.
@@ -164,12 +166,16 @@ function ExerciseDetail({ exercise }) {
 
       {started && (
         <div className="space-y-6 mt-4">
-          {exercise.items?.map((item) => (
-            <div key={item.item_id} className="bg-white p-4 rounded-md shadow">
-              <p className="mb-2 font-medium">{item.prompt}</p>
-              {renderItemInput(item)}
-            </div>
-          ))}
+          {exercise.items && exercise.items.length > 0 ? (
+            exercise.items.map((item) => (
+              <div key={item.item_id} className="bg-white p-4 rounded-md shadow">
+                <p className="mb-2 font-medium">{item.prompt}</p>
+                {renderItemInput(item)}
+              </div>
+            ))
+          ) : (
+            <p className="text-gray-500">No hay preguntas para este ejercicio.</p>
+          )}
         </div>
       )}
     </div>

--- a/MentorIA/src/components/IncomeStatement.jsx
+++ b/MentorIA/src/components/IncomeStatement.jsx
@@ -1,20 +1,33 @@
 import React from 'react';
 
+/**
+ * IncomeStatement
+ * ---------------
+ * Simple table that renders the income statement for a given year. The JSON
+ * data might provide each line under the key `label` or `concept`, so we
+ * support both.
+ */
 const IncomeStatement = ({ year = 2023, lines = [] }) => (
   <div className="overflow-x-auto">
     <h2 className="text-lg font-semibold mb-2">Estado de Resultados {year}</h2>
     <table className="min-w-full divide-y divide-gray-200 text-sm">
       <thead className="bg-gray-50">
         <tr>
-          <th className="px-4 py-2 text-left font-medium text-gray-700">Concepto</th>
-          <th className="px-4 py-2 text-right font-medium text-gray-700">Monto</th>
+          <th className="px-4 py-2 text-left font-medium text-gray-700">
+            Concepto
+          </th>
+          <th className="px-4 py-2 text-right font-medium text-gray-700">
+            Monto
+          </th>
         </tr>
       </thead>
       <tbody className="bg-white divide-y divide-gray-200">
         {lines.map((line, idx) => (
           <tr key={idx}>
-            <td className="px-4 py-2">{line.label}</td>
-            <td className="px-4 py-2 text-right">{line.amount.toLocaleString()}</td>
+            <td className="px-4 py-2">{line.label || line.concept}</td>
+            <td className="px-4 py-2 text-right">
+              {Number(line.amount).toLocaleString()}
+            </td>
           </tr>
         ))}
       </tbody>


### PR DESCRIPTION
## Summary
- display course title and error/loading states for accounting course
- handle dynamic IncomeStatement fields
- show fallback when no exercise items are present

## Testing
- `npm test --silent` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `cd MentorIA && npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ed86fe9d08333abd532d0b6e305fa