### PR TITLE
Update messages for accounting course

### DIFF
--- a/MentorIA/src/pages/AccountingCourse.tsx
+++ b/MentorIA/src/pages/AccountingCourse.tsx
@@ -45,7 +45,7 @@ export default function AccountingCourse(): JSX.Element {
       })
       .catch((err) => {
         console.error('Failed to load accounting questions:', err);
-        setError('Error al cargar los ejercicios');
+        setError('Error loading exercises. Please try again.');
       })
       .finally(() => setLoading(false));
   }, []);
@@ -60,7 +60,7 @@ export default function AccountingCourse(): JSX.Element {
       <div className="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
         <h1 className="text-3xl font-bold mb-6">Contabilidad</h1>
         {loading && (
-          <p className="text-gray-500">Cargando ejercicios...</p>
+          <p className="text-gray-500">Loading exercises...</p>
         )}
         {error && !loading && (
           <p className="text-red-600 mb-4">{error}</p>

--- a/MentorIA/src/pages/__tests__/AccountingCourse.test.tsx
+++ b/MentorIA/src/pages/__tests__/AccountingCourse.test.tsx
@@ -22,8 +22,13 @@ describe('AccountingCourse', () => {
   it('renders exercise titles after fetch', async () => {
     render(<AccountingCourse />);
 
+    // Loading message should appear initially
+    expect(screen.getByText('Loading exercises...')).toBeInTheDocument();
+
     for (const ex of mockExercises) {
       expect(await screen.findByText(ex.title)).toBeInTheDocument();
     }
+
+    expect(screen.queryByText('Loading exercises...')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- switch AccountingCourse loading message to "Loading exercises..."
- show English error message
- check loading message in AccountingCourse test

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_685edecd840083338a1e73745181efdb