### PR TITLE
Fix vitest script

### DIFF
--- a/MentorIA/package.json
+++ b/MentorIA/package.json
@@ -8,9 +8,10 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "node node_modules/vitest/vitest.mjs run"
   },
   "dependencies": {
+    "@rollup/wasm-node": "^4.44.1",
     "chart.js": "^4.4.1",
     "framer-motion": "^11.0.5",
     "lucide-react": "^0.344.0",
@@ -31,12 +32,12 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",
     "globals": "^15.9.0",
+    "jsdom": "^24.0.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
     "vite": "^5.4.2",
-    "vitest": "^1.5.1",
-    "jsdom": "^24.0.0"
+    "vitest": "^1.5.1"
   }
 }

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Courses are described by the `Course` interface found in `project/src/types`.
 A course may optionally include structured `chapters` which are defined by the
 `Chapter` type. Each chapter lists its concepts so that teachers can create
 targeted practice sessions.
+
+## Running Tests
+
+Execute `npm test --prefix MentorIA` to run the Vitest suite in non-watch mode.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "vitest": "^3.2.4"
   }
 }


### PR DESCRIPTION
## Summary
- run vitest in non-watch mode from MentorIA package
- document how to run the test suite
- align dev dependencies to include React

## Testing
- `npm test --prefix MentorIA` *(fails: Cannot read properties of null (reading 'useState'))*

------
https://chatgpt.com/codex/tasks/task_e_685efe09d3088333a1d9dada9b9dd757