### PR TITLE
Fix fetch path for accounting exercises

### DIFF
--- a/MentorIA/src/pages/AccountingCourse.tsx
+++ b/MentorIA/src/pages/AccountingCourse.tsx
@@ -31,7 +31,9 @@ useEffect(() => {
     setLoading(true);
     try {
       // Fetch accounting practice questions JSON
-      const res = await fetch('/preguntas-contabilidad.json');
+      const res = await fetch(
+        `${import.meta.env.BASE_URL}preguntas-contabilidad.json`
+      );
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
       }

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This project provides an adaptive learning platform built with React.
 
 The example accounting questions used in the demo now live under
 `MentorIA/public/preguntas-contabilidad.json`. Static assets placed in the
-`public` directory are served from the root path, so the file can still be
-fetched via `/preguntas-contabilidad.json` in the frontend code.
+`public` directory are served relative to the app's base path. The file is
+now fetched using `${import.meta.env.BASE_URL}preguntas-contabilidad.json` in
+the frontend code so deployments under different base URLs work correctly.
 
 ## Data Types
 


### PR DESCRIPTION
## Summary
- prefix accounting questions file path with `import.meta.env.BASE_URL`
- update README to document new path usage

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_685efe0759388333a73a26b74c5a89a4