### PR TITLE
Add FinancialStatements component to exercise detail

### DIFF
--- a/MentorIA/src/components/ExerciseDetail.jsx
+++ b/MentorIA/src/components/ExerciseDetail.jsx
@@ -3,6 +3,8 @@ import AdditionalInfo from './AdditionalInfo';
 import EntryInput from './EntryInput';
 import TAccountEditor from './TAccountEditor';
 import IncomeStatement from './IncomeStatement';
+// New consolidated financial statement component
+import FinancialStatements from './FinancialStatements';
 
 /**
  * ExerciseDetail
@@ -166,6 +168,13 @@ function ExerciseDetail({ exercise }) {
 
       {started && (
         <div className="space-y-6 mt-4">
+          {/* Consolidated financial statements shown before the questions */}
+          <FinancialStatements
+            balance2022={exercise.balance_2022 || []}
+            balance2023={exercise.balance_2023 || []}
+            incomeStatement={exercise.income_statement_2023?.lines || []}
+          />
+
           {exercise.items && exercise.items.length > 0 ? (
             exercise.items.map((item) => (
               <div key={item.item_id} className="bg-white p-4 rounded-md shadow">

--- a/MentorIA/src/pages/__tests__/AccountingCourse.test.tsx
+++ b/MentorIA/src/pages/__tests__/AccountingCourse.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+// Use the Vitest compatible version so that "expect" is correctly patched
+import '@testing-library/jest-dom/vitest';
 import AccountingCourse from '../AccountingCourse';
 
 const mockExercises = [

--- a/MentorIA/vitest.config.ts
+++ b/MentorIA/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // use a DOM-like environment without needing extra deps
+    environment: 'happy-dom',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "scripts": {
-    "test": "node node_modules/vitest/vitest.mjs"
+    "test": "node node_modules/vitest/vitest.mjs run --config MentorIA/vitest.config.ts"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "happy-dom": "^18.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "vitest": "^3.2.4"


### PR DESCRIPTION
## Summary
- import and render `FinancialStatements` in `ExerciseDetail`
- provide the exercise balance and income statement as props
- fix tests by loading `jest-dom` through Vitest helper
- add Vitest config using `happy-dom` environment
- run tests via custom script

## Testing
- `npm test` *(fails: Invalid hook call)*

------
https://chatgpt.com/codex/tasks/task_e_685f07f5fa90833382fd1ad4c1c88a57