### PR TITLE
Fix Vitest config alias

### DIFF
--- a/MentorIA/vitest.config.ts
+++ b/MentorIA/vitest.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      react: resolve(__dirname, 'node_modules/react'),
+      'react-dom': resolve(__dirname, 'node_modules/react-dom'),
+    },
+  },
   test: {
     // use a DOM-like environment without needing extra deps
     environment: 'happy-dom',


### PR DESCRIPTION
## Summary
- align vitest to use React from local node_modules

## Testing
- `npm test --prefix MentorIA` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686d8f01128c83338a6722395dc94622