### PR TITLE
Refactor UI components with Tailwind cards and buttons

### DIFF
--- a/MentorIA/src/components/AdditionalInfo.jsx
+++ b/MentorIA/src/components/AdditionalInfo.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import Card from './ui/Card';
 
 const AdditionalInfo = ({ items = [] }) => {
   const [openIndex, setOpenIndex] = useState(null);
@@ -10,20 +11,21 @@ const AdditionalInfo = ({ items = [] }) => {
   return (
     <div className="space-y-2">
       {items.map((item, index) => (
-        <div key={index} className="border rounded-md">
+        <Card key={index} className="overflow-hidden">
           <button
             type="button"
             onClick={() => toggle(index)}
-            className="w-full p-2 text-left font-medium bg-gray-100"
+            aria-expanded={openIndex === index}
+            className="w-full p-3 text-left font-semibold bg-gray-100 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-primary-500"
           >
             {item.title}
           </button>
           {openIndex === index && (
-            <div className="p-2 bg-white border-t">
-              {typeof item.content === 'string' ? <p>{item.content}</p> : item.content}
+            <div className="p-3 border-t">
+              {typeof item.content === 'string' ? <p className="text-gray-700">{item.content}</p> : item.content}
             </div>
           )}
-        </div>
+        </Card>
       ))}
     </div>
   );

--- a/MentorIA/src/components/BalanceSheet.jsx
+++ b/MentorIA/src/components/BalanceSheet.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Card from './ui/Card';
 
 const BalanceSheet = ({ year, data = {} }) => {
   const { assets = [], liabilities = [], equity = [] } = data;
@@ -6,7 +7,8 @@ const BalanceSheet = ({ year, data = {} }) => {
   const total = (arr) => arr.reduce((sum, item) => sum + (item.amount || 0), 0);
 
   const renderSection = (title, items) => (
-    <table className="min-w-full divide-y divide-gray-200 text-sm mb-4">
+    <Card className="p-4 mb-4 overflow-auto">
+      <table className="min-w-full divide-y divide-gray-200 text-sm">
       <thead className="bg-gray-50">
         <tr>
           <th className="px-4 py-2 text-left font-medium text-gray-700" colSpan="2">
@@ -28,7 +30,8 @@ const BalanceSheet = ({ year, data = {} }) => {
           </td>
         </tr>
       </tbody>
-    </table>
+      </table>
+    </Card>
   );
 
   return (

--- a/MentorIA/src/components/ChapterForm.tsx
+++ b/MentorIA/src/components/ChapterForm.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Chapter, Subtopic } from '../types/structuredCourse';
 import SubtopicForm from './SubtopicForm';
 import { v4 as uuidv4 } from 'uuid';
+import Card from './ui/Card';
+import Button from './ui/Button';
 
 interface ChapterFormProps {
   chapter: Chapter;
@@ -29,7 +31,7 @@ const ChapterForm: React.FC<ChapterFormProps> = ({ chapter, onChange, onDelete }
   };
 
   return (
-    <div className="p-4 border rounded-lg mb-6">
+    <Card className="p-4 mb-6 space-y-4">
       <div className="flex justify-between items-center mb-3">
         <input
           type="text"
@@ -38,9 +40,9 @@ const ChapterForm: React.FC<ChapterFormProps> = ({ chapter, onChange, onDelete }
           placeholder="Chapter title"
           className="flex-1 p-2 border rounded-lg"
         />
-        <button type="button" onClick={onDelete} className="ml-2 text-red-600">
+        <Button type="button" onClick={onDelete} className="ml-2 bg-red-600 hover:bg-red-700">
           Remove
-        </button>
+        </Button>
       </div>
       {chapter.subtopics.map((subtopic, index) => (
         <SubtopicForm
@@ -50,10 +52,10 @@ const ChapterForm: React.FC<ChapterFormProps> = ({ chapter, onChange, onDelete }
           onDelete={() => deleteSubtopic(index)}
         />
       ))}
-      <button type="button" onClick={addSubtopic} className="text-sm text-primary-600 mt-2">
+      <Button type="button" onClick={addSubtopic} className="text-sm mt-2">
         + Add Subtopic
-      </button>
-    </div>
+      </Button>
+    </Card>
   );
 };
 

--- a/MentorIA/src/components/ConceptForm.tsx
+++ b/MentorIA/src/components/ConceptForm.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Concept } from '../types/structuredCourse';
+import Button from './ui/Button';
 
 interface ConceptFormProps {
   concept: Concept;
@@ -17,9 +18,9 @@ const ConceptForm: React.FC<ConceptFormProps> = ({ concept, onChange, onDelete }
         placeholder="Concept title"
         className="flex-1 p-2 border rounded-lg"
       />
-      <button type="button" onClick={onDelete} className="ml-2 text-red-600">
+      <Button type="button" onClick={onDelete} className="ml-2 bg-red-600 hover:bg-red-700">
         Remove
-      </button>
+      </Button>
     </div>
   );
 };

--- a/MentorIA/src/components/CourseCard.tsx
+++ b/MentorIA/src/components/CourseCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Course } from '../types';
 import { motion } from 'framer-motion';
 import { BookOpen, User } from 'lucide-react';
+import Button from './ui/Button';
 
 interface CourseCardProps {
   course: Course;
@@ -49,14 +50,11 @@ const CourseCard: React.FC<CourseCardProps> = ({
           </div>
         )}
         
-        <button
-          onClick={() => onSelect(course.id)}
-          className="w-full bg-primary-600 text-white py-2 rounded-md hover:bg-primary-700 transition-colors flex items-center justify-center"
-        >
+        <Button onClick={() => onSelect(course.id)} className="w-full flex items-center justify-center">
           <span>
             {isFrameworkCourse ? 'Seleccionar cap\u00edtulo' : 'Seleccionar curso'}
           </span>
-        </button>
+        </Button>
       </div>
     </motion.div>
   );

--- a/MentorIA/src/components/CourseFrameworkBuilder.tsx
+++ b/MentorIA/src/components/CourseFrameworkBuilder.tsx
@@ -3,6 +3,8 @@ import { v4 as uuidv4 } from 'uuid';
 import ChapterForm from './ChapterForm';
 import { Chapter as StructuredChapter } from '../types/structuredCourse';
 import { CourseFramework } from '../types/courseFramework';
+import Card from './ui/Card';
+import Button from './ui/Button';
 
 interface Props {
   course?: CourseFramework;
@@ -88,7 +90,8 @@ const CourseFrameworkBuilder: React.FC<Props> = ({ course, teacherId, onSave, on
   };
 
   return (
-    <form onSubmit={handleSubmit} className="bg-white p-4 rounded-lg border space-y-4">
+    <form onSubmit={handleSubmit}>
+      <Card className="p-4 space-y-4">
       <div>
         <label className="block text-sm font-medium mb-1">Course Name</label>
         <input
@@ -120,19 +123,20 @@ const CourseFrameworkBuilder: React.FC<Props> = ({ course, teacherId, onSave, on
             onDelete={() => deleteChapter(index)}
           />
         ))}
-        <button type="button" onClick={addChapter} className="text-sm text-primary-600">
+        <Button type="button" onClick={addChapter} className="text-sm">
           + Add Chapter
-        </button>
+        </Button>
       </div>
 
       <div className="pt-4 flex justify-end space-x-4">
-        <button type="button" onClick={onCancel} className="px-4 py-2 text-gray-700 bg-gray-200 rounded-md">
+        <Button type="button" onClick={onCancel} className="bg-gray-200 text-gray-700 hover:bg-gray-300">
           Cancel
-        </button>
-        <button type="submit" className="px-4 py-2 bg-primary-600 text-white rounded-lg">
+        </Button>
+        <Button type="submit">
           Save Course
-        </button>
+        </Button>
       </div>
+      </Card>
     </form>
   );
 };

--- a/MentorIA/src/components/IncomeStatement.jsx
+++ b/MentorIA/src/components/IncomeStatement.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Card from './ui/Card';
 
 /**
  * IncomeStatement
@@ -8,7 +9,7 @@ import React from 'react';
  * support both.
  */
 const IncomeStatement = ({ year = 2023, lines = [] }) => (
-  <div className="overflow-x-auto">
+  <Card className="p-4 overflow-auto">
     <h2 className="text-lg font-semibold mb-2">Estado de Resultados {year}</h2>
     <table className="min-w-full divide-y divide-gray-200 text-sm">
       <thead className="bg-gray-50">
@@ -32,7 +33,7 @@ const IncomeStatement = ({ year = 2023, lines = [] }) => (
         ))}
       </tbody>
     </table>
-  </div>
+  </Card>
 );
 
 export default IncomeStatement;

--- a/MentorIA/src/components/LoadingSpinner.tsx
+++ b/MentorIA/src/components/LoadingSpinner.tsx
@@ -5,7 +5,10 @@ interface LoadingSpinnerProps {
 }
 
 const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ className = '' }) => (
-  <div className={`animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary-600 ${className}`}></div>
+  <div
+    role="status"
+    className={`animate-spin rounded-full h-12 w-12 border-4 border-primary-600 border-t-transparent ${className}`}
+  />
 );
 
 export default LoadingSpinner;

--- a/MentorIA/src/components/Navigation.tsx
+++ b/MentorIA/src/components/Navigation.tsx
@@ -31,7 +31,7 @@ const Navigation: React.FC = () => {
               <button
                 key={item.path}
                 onClick={() => navigate(item.path)}
-                className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-primary-500 ${
                   location.pathname === item.path
                     ? 'border-primary-500 text-gray-900'
                     : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
@@ -67,7 +67,7 @@ const Navigation: React.FC = () => {
             <button
               key={item.path}
               onClick={() => navigate(item.path)}
-              className={`flex flex-col items-center py-2 ${
+              className={`flex flex-col items-center py-2 focus:outline-none focus:ring-2 focus:ring-primary-500 ${
                 location.pathname === item.path
                   ? 'text-primary-600'
                   : 'text-gray-500'

--- a/MentorIA/src/components/SubtopicForm.tsx
+++ b/MentorIA/src/components/SubtopicForm.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Subtopic, Concept } from '../types/structuredCourse';
 import ConceptForm from './ConceptForm';
 import { v4 as uuidv4 } from 'uuid';
+import Card from './ui/Card';
+import Button from './ui/Button';
 
 interface SubtopicFormProps {
   subtopic: Subtopic;
@@ -29,7 +31,7 @@ const SubtopicForm: React.FC<SubtopicFormProps> = ({ subtopic, onChange, onDelet
   };
 
   return (
-    <div className="p-4 border rounded-lg mb-4">
+    <Card className="p-4 mb-4 space-y-2">
       <div className="flex justify-between items-center mb-2">
         <input
           type="text"
@@ -38,9 +40,9 @@ const SubtopicForm: React.FC<SubtopicFormProps> = ({ subtopic, onChange, onDelet
           placeholder="Subtopic title"
           className="flex-1 p-2 border rounded-lg"
         />
-        <button type="button" onClick={onDelete} className="ml-2 text-red-600">
+        <Button type="button" onClick={onDelete} className="ml-2 bg-red-600 hover:bg-red-700">
           Remove
-        </button>
+        </Button>
       </div>
       {subtopic.concepts.map((concept, index) => (
         <ConceptForm
@@ -50,10 +52,10 @@ const SubtopicForm: React.FC<SubtopicFormProps> = ({ subtopic, onChange, onDelet
           onDelete={() => deleteConcept(index)}
         />
       ))}
-      <button type="button" onClick={addConcept} className="text-sm text-primary-600 mt-2">
+      <Button type="button" onClick={addConcept} className="text-sm mt-2">
         + Add Concept
-      </button>
-    </div>
+      </Button>
+    </Card>
   );
 };
 

--- a/MentorIA/src/components/TAccountEditor.jsx
+++ b/MentorIA/src/components/TAccountEditor.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import Card from './ui/Card';
+import Button from './ui/Button';
 
 /**
  * TAccountEditor renders a dynamic table used for Cuenta T Maestra or
@@ -35,7 +37,8 @@ function TAccountEditor({ rows = [], onChange }) {
 
   return (
     <div>
-      <table className="min-w-full text-sm border">
+      <Card className="p-4 overflow-auto">
+        <table className="min-w-full text-sm">
         <thead className="bg-gray-100">
           <tr>
             <th className="p-2 border">Concepto</th>
@@ -99,14 +102,11 @@ function TAccountEditor({ rows = [], onChange }) {
             </tr>
           ))}
         </tbody>
-      </table>
-      <button
-        type="button"
-        onClick={addRow}
-        className="mt-3 px-4 py-2 bg-primary-600 text-white rounded"
-      >
+        </table>
+      </Card>
+      <Button type="button" onClick={addRow} className="mt-3">
         Agregar fila
-      </button>
+      </Button>
     </div>
   );
 }

--- a/MentorIA/src/components/ui/Button.tsx
+++ b/MentorIA/src/components/ui/Button.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+}
+
+const Button: React.FC<ButtonProps> = ({ className = '', children, ...props }) => (
+  <button
+    className={`bg-primary-600 text-white px-4 py-2 rounded-md hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 active:bg-primary-800 disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+    {...props}
+  >
+    {children}
+  </button>
+);
+
+export default Button;

--- a/MentorIA/src/components/ui/Card.tsx
+++ b/MentorIA/src/components/ui/Card.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+const Card: React.FC<CardProps> = ({ className = '', children, ...props }) => (
+  <div className={`bg-white rounded-lg shadow-md ${className}`} {...props}>
+    {children}
+  </div>
+);
+
+export default Card;


### PR DESCRIPTION
## Summary
- add reusable `Card` and `Button` components
- restyle info accordion with focus and card styling
- convert balance sheet, income statement and account editor to cards
- extract button styles in chapter, subtopic and concept forms
- refine course framework builder and course card
- improve navigation focus styles and loading spinner accessibility

## Testing
- `npm test --silent` *(fails: vitest Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_687158b074048333896505ea36ad6375