### PR TITLE
Fix accounting course navigation

### DIFF
--- a/MentorIA/src/pages/CourseOnboardingPage.tsx
+++ b/MentorIA/src/pages/CourseOnboardingPage.tsx
@@ -141,7 +141,11 @@ const CourseOnboardingPage: React.FC = () => {
           </button>
           
           <button
-            onClick={() => navigate(`/practice/${courseId}`)}
+            onClick={() =>
+              courseId === 'accounting'
+                ? navigate('/contabilidad')
+                : navigate(`/practice/${courseId}`)
+            }
             className="px-6 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 transition-colors"
           >
             Start Practice

--- a/MentorIA/src/pages/CourseSelectionPage.tsx
+++ b/MentorIA/src/pages/CourseSelectionPage.tsx
@@ -30,26 +30,13 @@ const CourseSelectionPage: React.FC = () => {
   }, []);
   
   const handleSelectStandardCourse = (courseId: string) => {
-    if (courseId === 'accounting') {
-      navigate('/contabilidad');
-    } else {
-      navigate(`/vark/${courseId}`);
-    }
+    navigate(`/vark/${courseId}`);
   };
   
   const handleSelectFrameworkCourse = (courseId: string) => {
     navigate(`/chapters/${courseId}`);
   };
 
-  const handleAccountingCourse = () => {
-    navigate('/contabilidad');
-  };
-
-  const accountingCourse: Course = {
-    id: 'contabilidad',
-    name: 'Contabilidad',
-    description: 'Conceptos b\u00e1sicos de contabilidad',
-  };
   
   return (
     <div className="min-h-screen bg-gray-50">
@@ -119,11 +106,6 @@ const CourseSelectionPage: React.FC = () => {
                       onSelect={handleSelectStandardCourse}
                     />
                   ))}
-                  <CourseCard
-                    key={accountingCourse.id}
-                    course={accountingCourse}
-                    onSelect={handleAccountingCourse}
-                  />
                 </div>
               </>
             )}


### PR DESCRIPTION
## Summary
- route all standard courses to VARK
- remove special accounting handlers
- send accounting to its practice route from onboarding

## Testing
- `npm install`
- `npx vitest`

------
https://chatgpt.com/codex/tasks/task_e_68716ac2dbcc833397308bef42263d7d