### PR TITLE
Fix path to types directory in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ the frontend code so deployments under different base URLs work correctly.
 
 ## Data Types
 
-Courses are described by the `Course` interface found in `project/src/types`.
+Courses are described by the `Course` interface found in `MentorIA/src/types`.
 A course may optionally include structured `chapters` which are defined by the
 `Chapter` type. Each chapter lists its concepts so that teachers can create
 targeted practice sessions.


### PR DESCRIPTION
## Summary
- update README to reference `MentorIA/src/types` for Course interface location

## Testing
- `npm test --prefix MentorIA` *(fails: vitest Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6871825d216883339ab46d63d39f31a8